### PR TITLE
Update the Node.js version in the CI to the release status version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 14]
+        node-version: [20, 18, 16]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Update supported versions to match Node.js Release Phases.

The current release status can be found below. Currently Node.js version 14 is EOL.
https://github.com/nodejs/release#release-schedule

Some libraries do not support version 14. For example, ``@typescript-eslint/parser@6.6.0`` may show the following, which is a version 14-specific error.
```
$ npm install
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN notsup Unsupported engine for @typescript-eslint/parser@6.6.0: wanted: {"node":"^16.0.0 || >=18.0.0"} (current: {"node":"14.0.0","npm":"6.14.4"})
```
At this time, only  ``devDependencies`` library is confirmed to have errors caused by Node.js version 14.
So I will update the versions of this library I support at this time.
