### PR TITLE
chore: update Node.js version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 18, 16]
+        node-version: [23, 22, 20]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Description

use the currently supported Node.js version in CI workflow.

https://nodejs.org/en/about/previous-releases